### PR TITLE
Join ensembles more efficiently

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -47,7 +47,7 @@ function apply(transform::Simulate, geotable::AbstractGeoTable)
   vars = Tables.columnnames(cols)
 
   (; domain, nreals, selectors, processes, rng, kwargs) = transform
-  ensembles = map(selectors, processes) do selector, process
+  ensembles = map(selectors, processes) do (selector, process)
     svars = selector(vars)
     data = geotable[:, svars]
     svars => rand(rng, process, domain, data, nreals; kwargs...)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -47,7 +47,7 @@ function apply(transform::Simulate, geotable::AbstractGeoTable)
   vars = Tables.columnnames(cols)
 
   (; domain, nreals, selectors, processes, rng, kwargs) = transform
-  ensembles = map(selectors, processes) do (selector, process)
+  ensembles = map(selectors, processes) do selector, process
     svars = selector(vars)
     data = geotable[:, svars]
     svars => rand(rng, process, domain, data, nreals; kwargs...)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -54,13 +54,13 @@ function apply(transform::Simulate, geotable::AbstractGeoTable)
   end
 
   pad = ndigits(nreals)
-  newgeotable = mapreduce(hcat, ensembles) do (vars, ensemble)
-    mapreduce(hcat, 1:nreals) do i
-      gtb = ensemble[i]
-      pairs = (v => "$(v)_$(string(i; pad))" for v in vars)
-      gtb |> Rename(pairs...)
+  pairs = mapreduce(vcat, ensembles) do (vars, ensemble)
+    mapreduce(vcat, 1:nreals) do i
+      [Symbol(v, :_, string(i; pad)) => ensemble[v][i] for v in vars]
     end
   end
+
+  newgeotable = georef((; pairs...), domain)
 
   newgeotable, nothing
 end


### PR DESCRIPTION
This PR brings improvements to first-run compilation time.
## Benchmark
main:
```
julia> using GeoStatsTransforms, GeoStatsProcesses, GeoStatsFunctions, GeoTables, Meshes

julia> gtb = georef((; a=rand(10, 10)));

julia> dom = CartesianGrid(100, 100);

julia> @time gtb |> Simulate(dom, 100, :a => GaussianProcess(GaussianVariogram()));
Simulating a: 100%|████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:15
 52.954089 seconds (160.39 M allocations: 18.220 GiB, 5.65% gc time, 77.95% compilation time: <1% of which was recompilation)

julia> @time gtb |> Simulate(dom, 100, :a => GaussianProcess(GaussianVariogram()));
Simulating a: 100%|████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:10
 10.620602 seconds (109.13 M allocations: 14.898 GiB, 11.41% gc time)
```
PR:
```
julia> using GeoStatsTransforms, GeoStatsProcesses, GeoStatsFunctions, GeoTables, Meshes

julia> gtb = georef((; a=rand(10, 10)));

julia> dom = CartesianGrid(100, 100);

julia> @time gtb |> Simulate(dom, 100, :a => GaussianProcess(GaussianVariogram()));
Simulating a: 100%|████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:14
 21.125534 seconds (131.76 M allocations: 16.378 GiB, 11.83% gc time, 46.31% compilation time: <1% of which was recompilation)

julia> @time gtb |> Simulate(dom, 100, :a => GaussianProcess(GaussianVariogram()));
Simulating a: 100%|████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:10
 10.823119 seconds (109.12 M allocations: 14.896 GiB, 9.55% gc time)
```
